### PR TITLE
fix: eslint caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write .",
     "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
     "postinstall": "remix setup node",
-    "lint": "eslint --cache-location ./node_modules/.cache/eslint .",
+    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "setup": "run-p \"test -- --run\" lint typecheck test:e2e:run",
     "test": "vitest",
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 'cypress open'",


### PR DESCRIPTION
You need to use the `--cache` flag as well as the `--cache-location` argument. e.g. (from a generated project):

```bash
> ./node_modules/.bin/eslint --cache-location ./node_modules/.cache/eslint .
> ls -l ./node_modules/.cache/
total 0
drwxr-xr-x  5 daniel  staff  160 18 Mar 08:03 remix
> ./node_modules/.bin/eslint --cache --cache-location ./node_modules/.cache/eslint .
> ls -l ./node_modules/.cache/
total 24
-rw-r--r--  1 daniel  staff  11817 18 Mar 08:32 eslint
drwxr-xr-x  5 daniel  staff    160 18 Mar 08:03 remix
```