### PR TITLE
feat(models): add User and Note type references

### DIFF
--- a/app/models/note.server.ts
+++ b/app/models/note.server.ts
@@ -1,22 +1,28 @@
-import cuid from "cuid";
 import arc from "@architect/functions";
+import cuid from "cuid";
+import { User } from "./user.server";
 
 export type Note = {
-  id: string;
-  userId: string;
+  id: ReturnType<typeof cuid>;
+  userId: User["id"];
   title: string;
   body: string;
 };
 
-const skToId = (sk: string) => sk.replace(/^note#/, "");
-const idToSk = (id: string) => `note#${id}`;
+type NoteItem = {
+  pk: User["id"];
+  sk: `note#${Note["id"]}`;
+};
+
+const skToId = (sk: NoteItem["sk"]): Note["id"] => sk.replace(/^note#/, "");
+const idToSk = (id: Note["id"]): NoteItem["sk"] => `note#${id}`;
 
 export async function getNote({
   userId,
   id,
 }: {
-  userId: string;
-  id: string;
+  userId: Note["userId"];
+  id: Note["id"];
 }): Promise<Note | null> {
   const db = await arc.tables();
 
@@ -36,7 +42,7 @@ export async function getNote({
 export async function getNoteListItems({
   userId,
 }: {
-  userId: string;
+  userId: Note["userId"];
 }): Promise<Array<Pick<Note, "id" | "title">>> {
   const db = await arc.tables();
 
@@ -56,9 +62,9 @@ export async function createNote({
   body,
   userId,
 }: {
-  title: string;
-  body: string;
-  userId: string;
+  title: Note["title"];
+  body: Note["body"];
+  userId: Note["userId"];
 }): Promise<Note> {
   const db = await arc.tables();
 
@@ -80,8 +86,8 @@ export async function deleteNote({
   id,
   userId,
 }: {
-  id: string;
-  userId: string;
+  id: Note["id"];
+  userId: Note["userId"];
 }) {
   const db = await arc.tables();
   return db.note.delete({ pk: userId, sk: idToSk(id) });

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -2,10 +2,10 @@ import arc from "@architect/functions";
 import bcrypt from "bcryptjs";
 import invariant from "tiny-invariant";
 
-export type User = { id: string; email: string };
+export type User = { id: `email#${string}`; email: string };
 export type Password = { password: string };
 
-export async function getUserById(id: string): Promise<User | null> {
+export async function getUserById(id: User["id"]): Promise<User | null> {
   const db = await arc.tables();
   const result = await db.user.query({
     KeyConditionExpression: "pk = :pk",
@@ -17,11 +17,11 @@ export async function getUserById(id: string): Promise<User | null> {
   return null;
 }
 
-export async function getUserByEmail(email: string) {
+export async function getUserByEmail(email: User["email"]) {
   return getUserById(`email#${email}`);
 }
 
-async function getUserPasswordByEmail(email: string) {
+async function getUserPasswordByEmail(email: User["email"]) {
   const db = await arc.tables();
   const result = await db.password.query({
     KeyConditionExpression: "pk = :pk",
@@ -34,7 +34,7 @@ async function getUserPasswordByEmail(email: string) {
   return null;
 }
 
-export async function createUser(email: string, password: string) {
+export async function createUser(email: User["email"], password: string) {
   const hashedPassword = await bcrypt.hash(password, 10);
   const db = await arc.tables();
   await db.password.put({
@@ -53,13 +53,13 @@ export async function createUser(email: string, password: string) {
   return user;
 }
 
-export async function deleteUser(email: string) {
+export async function deleteUser(email: User["email"]) {
   const db = await arc.tables();
   await db.password.delete({ pk: `email#${email}` });
   await db.user.delete({ pk: `email#${email}` });
 }
 
-export async function verifyLogin(email: string, password: string) {
+export async function verifyLogin(email: User["email"], password: string) {
   const userPassword = await getUserPasswordByEmail(email);
 
   if (!userPassword) {

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -25,7 +25,9 @@ export async function getSession(request: Request) {
   return sessionStorage.getSession(cookie);
 }
 
-export async function getUserId(request: Request): Promise<string | undefined> {
+export async function getUserId(
+  request: Request
+): Promise<User["id"] | undefined> {
   const session = await getSession(request);
   const userId = session.get(USER_SESSION_KEY);
   return userId;
@@ -44,7 +46,7 @@ export async function getUser(request: Request): Promise<null | User> {
 export async function requireUserId(
   request: Request,
   redirectTo: string = new URL(request.url).pathname
-): Promise<string> {
+): Promise<User["id"]> {
   const userId = await getUserId(request);
   if (!userId) {
     const searchParams = new URLSearchParams([["redirectTo", redirectTo]]);


### PR DESCRIPTION
**tldr**: This PR includes semantic TS only changes

- Add type references between models - 470c91be42847daeba7eadd17806f560da841faf

Reasoning: As Dynamo models grow, the ability to add relations between models can be illustrated and documented with TS. This is especially true for single table design patterns as seen below where we can see that a note record's `pk` is a reference to the user's `id`, which is of type: `note#${string}`. The note's `id` on the other hand is a `cuid` which is documented with type `ReturnType<typeof cuid>`

![Screen Shot 2022-03-18 at 11 06 17](https://user-images.githubusercontent.com/44626877/158973286-6cd38104-aba5-4568-ab5c-b3330a38defb.png)
![Screen Shot 2022-03-18 at 11 06 45](https://user-images.githubusercontent.com/44626877/158973353-856f2cfd-d6da-47d1-9751-04187185b071.png)

