### PR TITLE
fix: fixed typo in id for aria error messages

### DIFF
--- a/app/routes/notes/new.tsx
+++ b/app/routes/notes/new.tsx
@@ -76,7 +76,7 @@ export default function NewNotePage() {
           />
         </label>
         {actionData?.errors?.title && (
-          <Alert className="pt-1 text-red-700" id="title=error">
+          <Alert className="pt-1 text-red-700" id="title-error">
             {actionData.errors.title}
           </Alert>
         )}
@@ -97,7 +97,7 @@ export default function NewNotePage() {
           />
         </label>
         {actionData?.errors?.body && (
-          <Alert className="pt-1 text-red-700" id="body=error">
+          <Alert className="pt-1 text-red-700" id="body-error">
             {actionData.errors.body}
           </Alert>
         )}


### PR DESCRIPTION
Fixed non-matching id's aria-errormessage and id.

Also see https://github.com/remix-run/indie-stack/pull/36 and https://github.com/remix-run/blues-stack/pull/34