### PR TITLE
fix: resolved form validation for no password

### DIFF
--- a/app/routes/join.tsx
+++ b/app/routes/join.tsx
@@ -38,7 +38,7 @@ export const action: ActionFunction = async ({ request }) => {
     );
   }
 
-  if (typeof password !== "string") {
+  if (typeof password !== "string" || password.length === 0) {
     return json<ActionData>(
       { errors: { password: "Password is required" } },
       { status: 400 }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -38,7 +38,7 @@ export const action: ActionFunction = async ({ request }) => {
     );
   }
 
-  if (typeof password !== "string") {
+  if (typeof password !== "string" || password.length === 0) {
     return json<ActionData>(
       { errors: { password: "Password is required" } },
       { status: 400 }


### PR DESCRIPTION
Currently if you don't include a password you get the validation message for Password is too short rather than Password is required.

const password = formData.get("password") returns an empty string so using typeof password !== "string" doesn't work.

I have included an extra check to check the length of the string just like it is being done in the notes form.

Same fix in the https://github.com/remix-run/indie-stack/pull/57 and https://github.com/remix-run/blues-stack/pull/51