### PR TITLE
add seed database script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ preferences.arc
 sam.json
 sam.yaml
 .env
+prefs.arc
 
 /cypress/screenshots
 /cypress/videos

--- a/prefs.arc.example
+++ b/prefs.arc.example
@@ -1,0 +1,4 @@
+# Copy this file and rename to `prefs.arc` to set your local preferences.
+
+@sandbox-startup
+ts-node ./seedDatabase.ts

--- a/seedDatabase.ts
+++ b/seedDatabase.ts
@@ -1,0 +1,7 @@
+import { createUser } from "./app/models/user.server";
+
+(async () => {
+  console.log('Seeding database...')
+  await createUser('dev@dev', 'password');
+  console.log('Database seeded')
+})();


### PR DESCRIPTION
Add script to seed the development database. 

The script doesn't run by default. The developer will need to add a [prefs.arc](https://arc.codes/docs/en/reference/configuration/local-preferences) file to enable it. 
