### PR TITLE
fix: remove React hydrate deprecation warning by upgrading to hydrateRoot

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,4 +1,4 @@
 import { RemixBrowser } from "@remix-run/react";
-import { hydrate } from "react-dom";
+import { hydrateRoot } from "react-dom/client";
 
-hydrate(<RemixBrowser />, document);
+hydrateRoot(document, <RemixBrowser />);


### PR DESCRIPTION
Pretty straight forward. Will probably do the same with the other stacks if this passes. 
