### PR TITLE
move msw to js to remove ts-node from our process

### DIFF
--- a/mocks/index.js
+++ b/mocks/index.js
@@ -1,4 +1,4 @@
-import { setupServer } from "msw/node";
+const { setupServer } = require("msw/node");
 
 const server = setupServer();
 

--- a/mocks/index.js
+++ b/mocks/index.js
@@ -1,2 +1,8 @@
-require("ts-node").register({ transpileOnly: true });
-require("./start");
+import { setupServer } from "msw/node";
+
+const server = setupServer();
+
+server.listen({ onUnhandledRequest: "bypass" });
+
+process.once("SIGINT", () => server.close());
+process.once("SIGTERM", () => server.close());

--- a/mocks/start.ts
+++ b/mocks/start.ts
@@ -1,8 +1,0 @@
-import { setupServer } from "msw/node";
-
-const server = setupServer();
-
-server.listen({ onUnhandledRequest: "bypass" });
-
-process.once("SIGINT", () => server.close());
-process.once("SIGTERM", () => server.close());


### PR DESCRIPTION
using ts-node / esbuild-requires messes with the module resolution and causes stack traces to break

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
