### PR TITLE
Add explicit github workflow permissions (similar to indie-stack PR #82)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
       - main
       - dev
   pull_request: {}
+permissions:
+    actions: write
+    contents: read
 
 defaults:
   run:


### PR DESCRIPTION
Addresses an issue affecting all new github repositories where styfle/cancel-workflow-actions step fails without explicit permissions on the workflow

@mcansh thanks for pointing this out