### PR TITLE
chore: use provided utility function

### DIFF
--- a/app/models/note.server.ts
+++ b/app/models/note.server.ts
@@ -62,7 +62,7 @@ export async function createNote({
 
   const result = await db.note.put({
     pk: userId,
-    sk: `note#${cuid()}`,
+    sk: idToSk(cuid()),
     title: title,
     body: body,
   });


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->

A small fix to use the provided utility function (as is done in `deleteNote` and `getNote`.