### PR TITLE
Fully automate developer setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,115 @@
+## Learn more about this file at 'https://www.gitpod.io/docs/references/gitpod-yml'
+##
+## This '.gitpod.yml' file when placed at the root of a project instructs
+## Gitpod how to prepare & build the project, start development environments
+## and configure continuous prebuilds. Prebuilds when enabled builds a project
+## like a CI server so you can start coding right away - no more waiting for
+## dependencies to download and builds to finish when reviewing pull-requests
+## or hacking on something new.
+##
+## With Gitpod you can develop software from any device (even iPads) via 
+## desktop or browser based versions of VS Code or any JetBrains IDE and
+## customise it to your individual needs - from themes to extensions, you
+## have full control.
+##
+## The easiest way to try out Gitpod is install the browser extenion:
+## 'https://www.gitpod.io/docs/browser-extension' or by prefixing
+## 'https://gitpod.io#' to the source control URL of any project.
+##
+## For example: 'https://gitpod.io#https://github.com/gitpod-io/gitpod'
+
+
+## The 'tasks' section defines how Gitpod prepares & builds this project
+## and how it can start development servers. With Gitpod, there are three
+## types of tasks:
+##
+## - before: Use this for tasks that need to run before init and before command. 
+## - init: Use this to configure prebuilds of heavy-lifting tasks such as
+##         downloading dependencies or compiling source code.
+## - command: Use this to start your database or application when the workspace starts.
+##
+## Learn more about these tasks at 'https://www.gitpod.io/docs/config-start-tasks'
+
+tasks: 
+  - name: Restore .env file
+    # https://www.gitpod.io/guides/automate-env-files-with-gitpod-environment-variables
+    # After making changes to .env, run this line to persist it to $DOTENV
+    #    gp env DOTENV="$(base64 .env | tr -d '\n')"
+    command: |
+      if [ -f .env ]; then
+        # If this workspace already has a .env, don't override it
+        # Local changes survive a workspace being opened and closed
+        # but they will not persist between separate workspaces for the same repo
+        echo "Found .env in workspace"
+      else
+        if [ -z "${DOTENV}" ]; then
+          # There is no $DOTENV from a previous workspace
+          # Default to the example .env
+          echo "Setting example .env"
+          cp .env.example .env 
+        else
+          # Environment variables set this way are shared between all your workspaces for this repo
+          # The lines below will read $DOTENV and print a .env file
+          echo "Restoring .env from Gitpod"
+          echo "${DOTENV}" | base64 -d > .env
+        fi
+      fi
+
+  - name: App
+    init: npm install && npm run build
+    command: npm run dev
+
+## The 'ports' section defines various ports your may listen on are 
+## configured in Gitpod on an authenticated URL. By default, all ports
+## are in private visibility state.
+##
+## Learn more about ports at 'https://www.gitpod.io/docs/config-ports'
+
+ports:
+ - port: 3000 # alternatively configure entire ranges via '8080-8090'
+   visibility: private # either 'public' or 'private' (default)
+   onOpen: open-browser # either 'open-browser', 'open-preview' or 'ignore'
+
+## The 'vscode' section defines a list of Visual Studio Code extensions from
+## the OpenVSX.org registry to be installed upon workspace startup. OpenVSX
+## is an open alternative to the proprietary Visual Studio Code Marketplace
+## and extensions can be added by sending a pull-request with the extension
+## identifier to https://github.com/open-vsx/publish-extensions
+##
+## The identifier of an extension is always ${publisher}.${name}.
+##
+## For example: 'vscodevim.vim'
+##
+## Learn more at 'https://www.gitpod.io/docs/ides-and-editors/vscode'
+
+vscode:
+  extensions:
+    - VisualStudioExptTeam.vscodeintellicode
+    - dbaeumer.vscode-eslint
+    - formulahendry.auto-rename-tag
+    - esbenp.prettier-vscode
+    - ms-azuretools.vscode-docker
+
+## The 'github' section defines configuration of continuous prebuilds
+## for GitHub repositories when the GitHub application
+## 'https://github.com/apps/gitpod-io' is installed in GitHub and granted
+## permissions to access the repository.
+##
+## Learn more at 'https://www.gitpod.io/docs/prebuilds'
+
+github: 
+  prebuilds:
+    # enable for the default branch
+    master: true
+    # enable for all branches in this repo
+    branches: false
+    # enable for pull requests coming from this repo
+    pullRequests: false
+    # enable for pull requests coming from forks
+    pullRequestsFromForks: false
+    # add a check to pull requests
+    addCheck: false
+    # add a "Review in Gitpod" button as a comment to pull requests
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description
+    addBadge: false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ npx create-remix --template remix-run/grunge-stack
 
 Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --template your/repo`! Make it your own.
 
+## Quickstart
+
+Click this button to create a [Gitpod](https://gitpod.io) workspace with the project set up
+
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
+
 ## Development
 
 - Validate the app has been set up properly (optional):


### PR DESCRIPTION
I've added Gitpod support to the Grunge Stack (here is a similar PR for the Indie Stack https://github.com/remix-run/indie-stack/pull/58)

When a user clicks the Gitpod button, they'll get a workspace with the environment variables set, Fly pre-installed, and the Postgres database running in Docker Compose ready to go. The application starts immediately and a user can create an account and add notes right away.

cc @MichaelDeBoey https://github.com/remix-run/blues-stack/pull/58#issuecomment-1150156324

You can test this workflow by clicking this button:

[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-forks/grunge-stack/)