### PR TITLE
chore: update how `PORT` is set

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,9 +113,9 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           start: npm run dev
-          wait-on: "http://localhost:3000"
+          wait-on: "http://localhost:8811"
         env:
-          PORT: "3000"
+          PORT: "8811"
 
   deploy:
     needs: [lint, typecheck, vitest, cypress]

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   e2e: {
     setupNodeEvents: (on, config) => {
-      const port = process.env.PORT ?? "3000";
+      const isDev = config.watchForFileChanges;
+      const port = process.env.PORT ?? (isDev ? "3000" : "8811");
       const configOverrides: Partial<Cypress.PluginConfigOptions> = {
         baseUrl: `http://localhost:${port}`,
         video: !process.env.CI,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "remix build",
     "dev": "run-p dev:*",
-    "dev:arc": "cross-env PORT=${PORT:=3000} ARC_LOCAL=${ARC_LOCAL:=1} ARC_TABLES_PORT=${ARC_TABLES_PORT:=5555} arc sandbox",
+    "sandbox": "cross-env ARC_LOCAL=1 ARC_TABLES_PORT=5555 arc sandbox",
+    "dev:arc": "cross-env PORT=3000 npm run sandbox",
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "remix watch",
     "format": "prettier --write .",
@@ -15,7 +16,7 @@
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "test": "vitest",
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 \"npx cypress open\"",
-    "test:e2e:run": "cross-env PORT=8811 start-server-and-test dev http://localhost:8811 \"npx cypress run\"",
+    "test:e2e:run": "cross-env PORT=8811 start-server-and-test sandbox http://localhost:8811 \"npx cypress run\"",
     "typecheck": "tsc -b && tsc -b cypress",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "remix build",
     "dev": "run-p dev:*",
-    "dev:arc": "cross-env PORT=3000 ARC_LOCAL=1 ARC_TABLES_PORT=5555 arc sandbox",
+    "dev:arc": "cross-env PORT=${PORT:=3000} ARC_LOCAL=${ARC_LOCAL:=1} ARC_TABLES_PORT=${ARC_TABLES_PORT:=5555} arc sandbox",
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "remix watch",
     "format": "prettier --write .",
@@ -15,12 +15,16 @@
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "test": "vitest",
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 \"npx cypress open\"",
-    "test:e2e:run": "cross-env PORT=3000 start-server-and-test dev http://localhost:3000 \"npx cypress run\"",
+    "test:e2e:run": "cross-env PORT=8811 start-server-and-test dev http://localhost:8811 \"npx cypress run\"",
     "typecheck": "tsc -b && tsc -b cypress",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },
   "prettier": {},
-  "eslintIgnore": ["/node_modules", "/server/index.js", "/public/build"],
+  "eslintIgnore": [
+    "/node_modules",
+    "/server/index.js",
+    "/public/build"
+  ],
   "dependencies": {
     "@architect/architect": "^10.3.3",
     "@architect/functions": "^5.1.0",


### PR DESCRIPTION
reverts part of https://github.com/remix-run/grunge-stack/pull/70 where we changed the default PORT for cypress, which then streamed down to our ["stacks" workflow](https://github.com/remix-run/remix/runs/6886451651?check_suite_focus=true) failing

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
