### PR TITLE
Revert "chore: remove dev.js"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,9 +113,9 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           start: npm run dev
-          wait-on: "http://localhost:3000"
+          wait-on: "http://localhost:8811"
         env:
-          PORT: "3000"
+          PORT: "8811"
 
   deploy:
     needs: [lint, typecheck, vitest, cypress]

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   e2e: {
     setupNodeEvents: (on, config) => {
-      const port = process.env.PORT ?? "3000";
+      const isDev = config.watchForFileChanges;
+      const port = process.env.PORT ?? (isDev ? "3000" : "8811");
       const configOverrides: Partial<Cypress.PluginConfigOptions> = {
         baseUrl: `http://localhost:${port}`,
         video: !process.env.CI,

--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,7 @@
+process.env.PORT = process.env.PORT ?? 3000;
+process.env.ARC_LOCAL = process.env.ARC_LOCAL ?? 1;
+process.env.ARC_TABLES_PORT = process.env.ARC_TABLES_PORT ?? 5555;
+
+const arc = require("@architect/architect");
+
+void arc();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "remix build",
     "dev": "run-p dev:*",
-    "dev:arc": "cross-env PORT=3000 ARC_LOCAL=1 ARC_TABLES_PORT=5555 arc sandbox",
+    "dev:arc": "node ./dev sandbox",
     "dev:css": "npm run generate:css -- --watch",
     "dev:remix": "remix watch",
     "format": "prettier --write .",
@@ -15,12 +15,16 @@
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "test": "vitest",
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 \"npx cypress open\"",
-    "test:e2e:run": "cross-env PORT=3000 start-server-and-test dev http://localhost:3000 \"npx cypress run\"",
+    "test:e2e:run": "cross-env PORT=8811 start-server-and-test dev http://localhost:8811 \"npx cypress run\"",
     "typecheck": "tsc -b && tsc -b cypress",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },
   "prettier": {},
-  "eslintIgnore": ["/node_modules", "/server/index.js", "/public/build"],
+  "eslintIgnore": [
+    "/node_modules",
+    "/server/index.js",
+    "/public/build"
+  ],
   "dependencies": {
     "@architect/architect": "^10.3.3",
     "@architect/functions": "^5.1.0",


### PR DESCRIPTION
Reverts #70 

causes a breakage in cypress due to the PORT being 3000 and we expect 8811