### PR TITLE
fix: remove double await

### DIFF
--- a/app/models/note.server.ts
+++ b/app/models/note.server.ts
@@ -24,7 +24,7 @@ export async function getNote({
 }: Pick<Note, "id" | "userId">): Promise<Note | null> {
   const db = await arc.tables();
 
-  const result = await await db.note.get({ pk: userId, sk: idToSk(id) });
+  const result = await db.note.get({ pk: userId, sk: idToSk(id) });
 
   if (result) {
     return {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->

Minor style(?) fix: I noticed a double await in the note model code that wasn't present in the user model code. That made me assume it was placed erroneously rather than DynamoDB actually requiring it. 

Thanks for the awesome template!