### PR TITLE
chore: update LoaderData and ActionData to be types instead of interfaces

### DIFF
--- a/app/routes/join.tsx
+++ b/app/routes/join.tsx
@@ -18,12 +18,12 @@ export const loader: LoaderFunction = async ({ request }) => {
   return json({});
 };
 
-interface ActionData {
+type ActionData = {
   errors: {
     email?: string;
     password?: string;
   };
-}
+};
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();
@@ -79,7 +79,7 @@ export const meta: MetaFunction = () => {
 export default function Join() {
   const [searchParams] = useSearchParams();
   const redirectTo = searchParams.get("redirectTo") ?? undefined;
-  const actionData = useActionData() as ActionData;
+  const actionData = useActionData<ActionData>();
   const emailRef = React.useRef<HTMLInputElement>(null);
   const passwordRef = React.useRef<HTMLInputElement>(null);
 

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -17,12 +17,12 @@ export const loader: LoaderFunction = async ({ request }) => {
   return json({});
 };
 
-interface ActionData {
+type ActionData = {
   errors?: {
     email?: string;
     password?: string;
   };
-}
+};
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();

--- a/app/routes/notes.tsx
+++ b/app/routes/notes.tsx
@@ -17,7 +17,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 };
 
 export default function NotesPage() {
-  const data = useLoaderData() as LoaderData;
+  const data = useLoaderData<LoaderData>();
   const user = useUser();
 
   return (

--- a/app/routes/notes/$noteId.tsx
+++ b/app/routes/notes/$noteId.tsx
@@ -33,7 +33,7 @@ export const action: ActionFunction = async ({ request, params }) => {
 };
 
 export default function NoteDetailsPage() {
-  const data = useLoaderData() as LoaderData;
+  const data = useLoaderData<LoaderData>();
 
   return (
     <div>


### PR DESCRIPTION
upstream type issue with `Serializable` https://github.com/remix-run/remix/runs/7240224157?check_suite_focus=true

Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
