### PR TITLE
fix: defineRoutes starts in the `appDirectory`

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -16,9 +16,12 @@ module.exports = {
       if (process.env.NODE_ENV === "production") return;
 
       console.log("⚠️  Test routes enabled.");
+
+      let appDir = path.join(__dirname, "app");
+
       route(
         "__tests/create-user",
-        path.join(__dirname, "cypress/support/test-routes/create-user.ts")
+        path.relative(appDir, "cypress/support/test-routes/create-user.ts")
       );
     });
   },


### PR DESCRIPTION
defineRoutes starts in the `appDirectory` so we need to go up a directory back to the root directory. feel free to update the PR title as you wish

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
