### PR TITLE
chore: ignore /server for git/prettie/eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ pnpm-lock.yml
 
 node_modules
 
-/server/index.js
-/server/index.js.map
+/server
 /public/build
 preferences.arc
 sam.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
 node_modules
 
-/server/index.js
+/server
 /public/build
 preferences.arc
 sam.json

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "prettier": {},
   "eslintIgnore": [
     "/node_modules",
-    "/server/index.js",
+    "/server",
     "/public/build"
   ],
   "dependencies": {

--- a/remix.init/gitignore
+++ b/remix.init/gitignore
@@ -1,6 +1,6 @@
 node_modules
 
-/server/index.js
+/server
 /public/build
 preferences.arc
 sam.json


### PR DESCRIPTION
After I created an app from the **grunge-slack** and run `npm run dev`, there are some new files will be generated in `/server` directory, but not be ignored by git/prettie/eslint.

![image](https://user-images.githubusercontent.com/95570352/192172455-a829297d-55a8-48ef-a9a3-6f2f510c4f81.png)

Sorry, I am new to remix, I think this directory only be used for server build files, so I create this PR. Are there any other files that need to be version controlled in `/server`?