### PR TITLE
fix: fix `typecheck` script

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -12,7 +12,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noEmit": true,
-    "types": ["node", "cypress", "@testing-library/cypress"],
+    "types": ["cypress", "@testing-library/cypress"],
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "moduleResolution": "node",

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -12,7 +12,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noEmit": true,
-    "types": ["cypress", "@testing-library/cypress"],
+    "types": ["node", "cypress", "@testing-library/cypress"],
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "moduleResolution": "node",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "vitest",
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 \"npx cypress open\"",
     "test:e2e:run": "cross-env PORT=8811 start-server-and-test dev http://localhost:8811 \"npx cypress run\"",
-    "typecheck": "tsc && tsc cypress",
+    "typecheck": "tsc && tsc -p cypress",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },
   "prettier": {},


### PR DESCRIPTION
Apparently we need to add the `-p` flag when running `tsc` on the `cypress` folder
https://github.com/remix-run/grunge-stack/actions/runs/3951229138/jobs/6764812112