### PR TITLE
feat: add `css-bundle` setup

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,12 +8,14 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
+import { cssBundleHref } from "@remix-run/css-bundle";
 
 import tailwindStylesheetUrl from "~/styles/tailwind.css";
 import { getUser } from "~/session.server";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: tailwindStylesheetUrl },
+  ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
   // NOTE: Architect deploys the public directory to /_static/
   { rel: "icon", href: "/_static/favicon.ico" },
 ];

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@architect/functions": "^5.4.0",
     "@paralleldrive/cuid2": "^2.2.0",
     "@remix-run/architect": "*",
+    "@remix-run/css-bundle": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/server-runtime": "*",


### PR DESCRIPTION
This ensures CSS bundling doesn't need to be manually set up before using any CSS bundling features which is particularly important since they'll be enabled by default in v1.16. By default this has no impact on the links returned from this app so there's zero cost for consumers.