### PR TITLE
chore: expand init instructions, clean after init

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --
 
 ## Development
 
-- This step only applies if you've opted out of having the CLI install dependencies for you:
+- First run this stack's `remix.init` script and commit the changes it makes to your project.
 
   ```sh
   npx remix init
+  git init # if you haven't already
+  git add .
+  git commit -m "Initialize project"
   ```
 
 - Validate the app has been set up properly (optional):

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -166,16 +166,28 @@ const main = async ({ isTypeScript, packageManager, rootDirectory }) => {
 
   updatePackageJson({ APP_NAME, isTypeScript, packageJson });
 
+  const initInstructions = `
+- First run this stack's \`remix.init\` script and commit the changes it makes to your project.
+
+  \`\`\`sh
+  npx remix init
+  git init # if you haven't already
+  git add .
+  git commit -m "Initialize project"
+  \`\`\`
+`;
+
+  const newReadme = readme
+    .replace(new RegExp("RemixGrungeStack", "g"), toLogicalID(APP_NAME))
+    .replace(initInstructions, "");
+
   const fileOperationPromises = [
     fs.writeFile(
       APP_ARC_PATH,
       appArc.replace("grunge-stack-template", APP_NAME)
     ),
     fs.writeFile(ENV_PATH, newEnv),
-    fs.writeFile(
-      README_PATH,
-      readme.replace(new RegExp("RemixGrungeStack", "g"), toLogicalID(APP_NAME))
-    ),
+    fs.writeFile(README_PATH, newReadme),
     packageJson.save(),
     fs.copyFile(
       path.join(rootDirectory, "remix.init", "gitignore"),


### PR DESCRIPTION
This change was motivated by some upcoming work in `create-remix` but this is still a useful change in the meantime that can go out immediately.

From an end user perspective, if the `remix.init` script runs during the `create-remix` flow, the `npx remix init` instructions are no longer present in the readme since they're redundant and just add noise.

For those that didn't already run the `remix.init` script (either because they opted out of installing dependencies, or because they cloned this repo directly), the instructions are now much clearer since they're not conditional — you don't have to remember whether or not you opted out of installing dependencies anymore. We also now make it clear that this script makes changes to your project that are intended to be committed.