### PR TITLE
fix: use exact Cypress version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@vitest/coverage-v8": "^0.34.2",
     "autoprefixer": "^10.4.15",
     "cross-env": "^7.0.3",
-    "cypress": "^12.17.4",
+    "cypress": "12.17.3",
     "esbuild": "^0.19.2",
     "eslint": "^8.47.0",
     "eslint-config-prettier": "^9.0.0",


### PR DESCRIPTION
Regression in Cypress with using `Cypress.Command.add`

Closes #160