### PR TITLE
fix: add `installGlobals` to server handler for node16.x

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,8 @@
 import { createRequestHandler } from "@remix-run/architect";
+import { installGlobals } from "@remix-run/node";
 import * as build from "@remix-run/dev/server-build";
+
+installGlobals();
 
 if (process.env.NODE_ENV !== "production") {
   require("./mocks");

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,6 @@
 import { createRequestHandler } from "@remix-run/architect";
-import { installGlobals } from "@remix-run/node";
 import * as build from "@remix-run/dev/server-build";
+import { installGlobals } from "@remix-run/node";
 
 installGlobals();
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
The app.arc file specifies the `node16.x` runtime, which doesn't have the Fetch globals (Request, Response, Headers, etc), so deploying this stack right after creating will have a `ReferenceError: Request is not defined`.